### PR TITLE
Updated to use the newest driver from NXP

### DIFF
--- a/recipes-kernel/nxp-wifi-bt/kernel-module-btmrvl.bb
+++ b/recipes-kernel/nxp-wifi-bt/kernel-module-btmrvl.bb
@@ -16,6 +16,9 @@ module_conf_bt8xxx_interface-diversity-usb-usb_mfg-mode = "options bt8xxx fw_nam
 KERNEL_MODULE_PROBECONF_append_interface-diversity-pcie-usb = " bt8xxx "
 module_conf_bt8xxx_interface-diversity-pcie-usb_mfg-mode = "options bt8xxx fw_name=nxp/pcie8997_usb_combo.bin"
 
+PCIE_WLAN_USB_FILE ?= "PCIE-WLAN-USB-BT-8997-U16-X86-W16.88.10.p173-16.26.10.p173-C4X16698_V4-GPL"
+USB_BT_SRC ?= "USB-BT-8997-U16-X86-16.26.10.p173-C4X14114_V4-GPL-src"
+
 SRC_URI = " \
     file://0001-makefile.patch \
 "
@@ -52,13 +55,13 @@ do_nxp_driver_unpack_interface-diversity-usb-usb() {
         -xf ${WORKDIR}/archive.usb-usb/USB-BT-8997-U16-X86-16.26.10.p136-C4X14114_V4-GPL-src.tgz
 }
 
-SRC_URI_append_interface-diversity-pcie-usb = " ${NXP_PROPRIETARY_DRIVER_LOCATION}/PCIE-WLAN-USB-BT-8997-U16-X86-W16.88.10.p70-16.26.10.p70-C4X16672_V4-GPL.zip;name=pcie-usb-driver;subdir=archive.pcie-usb "
+SRC_URI_append_interface-diversity-pcie-usb = " ${NXP_PROPRIETARY_DRIVER_LOCATION}/${PCIE_WLAN_USB_FILE}.zip;name=pcie-usb-driver;subdir=archive.pcie-usb "
 SRC_URI[pcie-usb-driver.sha256sum] = "9c56bffc33e134d3f7502fdf12ee9b0c6b8f9a12c4ef73f6dd0c349384375b4f"
 do_nxp_driver_unpack_interface-diversity-pcie-usb() {
     tar -C ${WORKDIR}/archive.pcie-usb/ \
-       -xf ${WORKDIR}/archive.pcie-usb/PCIE-WLAN-USB-BT-8997-U16-X86-W16.88.10.p70-16.26.10.p70-C4X16672_V4-GPL.tar \
-           USB-BT-8997-U16-X86-16.26.10.p70-C4X14114_V4-GPL-src.tgz
+       -xf ${WORKDIR}/archive.pcie-usb/${PCIE_WLAN_USB_FILE}.tar \
+           ${USB_BT_SRC}.tgz
     tar --strip-components=1 \
          -C ${WORKDIR} \
-        -xf ${WORKDIR}/archive.pcie-usb/USB-BT-8997-U16-X86-16.26.10.p70-C4X14114_V4-GPL-src.tgz
+        -xf ${WORKDIR}/archive.pcie-usb/${USB_BT_SRC}.tgz
 }

--- a/recipes-kernel/nxp-wifi-bt/kernel-module-wifimrvl.bb
+++ b/recipes-kernel/nxp-wifi-bt/kernel-module-wifimrvl.bb
@@ -23,6 +23,10 @@ KERNEL_MODULE_PROBECONF_append_interface-diversity-pcie-usb = " ${KERNEL_MODULE_
 module_conf_pcie8xxx_interface-diversity-pcie-usb = "options pcie8xxx cal_data_cfg=nxp/cal_data.conf cfg80211_wext=12"
 module_conf_pcie8xxx_interface-diversity-pcie-usb_mfg-mode = "options pcie8xxx cal_data_cfg=none cfg80211_wext=0xf mfg_mode=1 fw_name=nxp/pcie8997_usb_combo.bin"
 
+PCIE_UAPSTA_FILENAME ?= "PCIE-UAPSTA-8997-U16-X86-W16.88.10.p173-C4X16698_V4"
+PCIE_UAPSTA_USB_BT ?= "PCIE-UAPSTA-USB-BT-8997-U16-X86-W16.88.10.p173-16.26.10.p173-C4X16698_V4-GPL"
+PCIE_WLAN_USB_FILE ?= "PCIE-WLAN-USB-BT-8997-U16-X86-W16.88.10.p173-16.26.10.p173-C4X16698_V4-GPL"
+
 SRC_URI = "\
     file://cal_data.conf \
     file://0001-makefile.patch \
@@ -83,19 +87,19 @@ do_nxp_driver_unpack_interface-diversity-usb-usb() {
     done
 }
 
-SRC_URI_append_interface-diversity-pcie-usb = " ${NXP_PROPRIETARY_DRIVER_LOCATION}/PCIE-WLAN-USB-BT-8997-U16-X86-W16.88.10.p70-16.26.10.p70-C4X16672_V4-GPL.zip;name=pcie-usb-driver;subdir=archive.pcie-usb "
+SRC_URI_append_interface-diversity-pcie-usb = " ${NXP_PROPRIETARY_DRIVER_LOCATION}/${PCIE_WLAN_USB_FILE}.zip;name=pcie-usb-driver;subdir=archive.pcie-usb "
 SRC_URI[pcie-usb-driver.sha256sum] = "9c56bffc33e134d3f7502fdf12ee9b0c6b8f9a12c4ef73f6dd0c349384375b4f"
 do_nxp_driver_unpack_interface-diversity-pcie-usb() {
     tar -C ${WORKDIR}/archive.pcie-usb/ \
-        -xf ${WORKDIR}/archive.pcie-usb/PCIE-WLAN-USB-BT-8997-U16-X86-W16.88.10.p70-16.26.10.p70-C4X16672_V4-GPL.tar \
-            PCIE-UAPSTA-8997-U16-X86-W16.88.10.p70-C4X16672_V4-app-src.tgz \
-            PCIE-UAPSTA-8997-U16-X86-W16.88.10.p70-C4X16672_V4-GPL-src.tgz \
-            PCIE-UAPSTA-8997-U16-X86-W16.88.10.p70-C4X16672_V4-mlan-src.tgz
-    for i in PCIE-UAPSTA-8997-U16-X86-W16.88.10.p70-C4X16672_V4-app-src.tgz \
-             PCIE-UAPSTA-8997-U16-X86-W16.88.10.p70-C4X16672_V4-GPL-src.tgz \
-             PCIE-UAPSTA-8997-U16-X86-W16.88.10.p70-C4X16672_V4-mlan-src.tgz; do
+        -xf ${WORKDIR}/archive.pcie-usb/${PCIE_WLAN_USB_FILE}.tar \
+            ${PCIE_UAPSTA_FILENAME}-app-src.tgz \
+            ${PCIE_UAPSTA_FILENAME}-GPL-src.tgz \
+            ${PCIE_UAPSTA_FILENAME}-mlan-src.tgz
+    for i in ${PCIE_UAPSTA_FILENAME}-app-src.tgz \
+             ${PCIE_UAPSTA_FILENAME}-GPL-src.tgz \
+             ${PCIE_UAPSTA_FILENAME}-mlan-src.tgz; do
         tar --strip-components=1 -C ${WORKDIR} \
             -xf ${WORKDIR}/archive.pcie-usb/$i \
-            PCIE-UAPSTA-USB-BT-8997-U16-X86-W16.88.10.p70-16.26.10.p70-C4X16672_V4-GPL/wlan_src
+            ${PCIE_UAPSTA_USB_BT}/wlan_src
     done
 }

--- a/recipes-kernel/nxp-wifi-bt/nxp-wifi-bt-firmware.bb
+++ b/recipes-kernel/nxp-wifi-bt/nxp-wifi-bt-firmware.bb
@@ -20,6 +20,8 @@ do_install() {
 
 COMPATIBLE_MACHINE = "(colibri-imx6ull|colibri-imx8x|verdin-imx8mm|verdin-imx8mp|apalis-imx8|apalis-imx8x)"
 
+PCIE_WLAN_USB_FILE ?= "PCIE-WLAN-USB-BT-8997-U16-X86-W16.88.10.p173-16.26.10.p173-C4X16698_V4-GPL"
+
 addtask nxp_driver_unpack before do_patch after do_unpack
 do_nxp_driver_unpack() {
     :
@@ -55,7 +57,7 @@ do_nxp_driver_unpack_interface-diversity-usb-usb_mfg-mode() {
     install -m 0644 ${WORKDIR}/archive.usb-usb/MFG-W8997-MF-LABTOOL-U14-1.1.0.164-A1-16.80.205.p164/bin/FwImage/${FIRMWARE_BIN} ${S}/${FIRMWARE_BIN}
 }
 
-NXP_DRIVER_PACKAGE_interface-diversity-pcie-usb="PCIE-WLAN-USB-BT-8997-U16-X86-W16.88.10.p70-16.26.10.p70-C4X16672_V4-GPL.zip;name=pcie-usb-driver"
+NXP_DRIVER_PACKAGE_interface-diversity-pcie-usb="${PCIE_WLAN_USB_FILE}.zip;name=pcie-usb-driver"
 NXP_DRIVER_PACKAGE_interface-diversity-pcie-usb_mfg-mode="MFG-W8997-MF-LABTOOL-U14-1.1.0.164-A1-16.80.205.p164.zip;name=pcie-usb-mfg-driver"
 SRC_URI_append_interface-diversity-pcie-usb = " ${NXP_PROPRIETARY_DRIVER_LOCATION}/${NXP_DRIVER_PACKAGE};subdir=archive.pcie-usb "
 SRC_URI[pcie-usb-driver.sha256sum] = "9c56bffc33e134d3f7502fdf12ee9b0c6b8f9a12c4ef73f6dd0c349384375b4f"
@@ -63,7 +65,7 @@ SRC_URI[pcie-usb-mfg-driver.sha256sum] = "599031b9040c3a501f656a30f85308b9a1929e
 do_nxp_driver_unpack_interface-diversity-pcie-usb() {
     tar -C ${S} \
         --strip-components=1 \
-        -xf ${WORKDIR}/archive.pcie-usb/PCIE-WLAN-USB-BT-8997-U16-X86-W16.88.10.p70-16.26.10.p70-C4X16672_V4-GPL.tar \
+        -xf ${WORKDIR}/archive.pcie-usb/${PCIE_WLAN_USB_FILE}.tar \
         FwImage/${FIRMWARE_BIN}
 }
 do_nxp_driver_unpack_interface-diversity-pcie-usb_mfg-mode() {


### PR DESCRIPTION
I've changed the recipes from this layer to use the latest wifi/bt driver from NXP: PCIE-WLAN-USB-BT-8997-U16-X86-W16.88.10.p173-16.26.10.p173-C4X16698_V4-GPL. Also, I created some weak assigned variables to address these filenames, so the user could export a new driver name to replace the one that I used inside the recipe.